### PR TITLE
Fix YAML loading

### DIFF
--- a/clay/config.py
+++ b/clay/config.py
@@ -16,7 +16,6 @@ SERIALIZERS = {'json': json}
 
 try:
     import yaml
-    yaml.load = yaml.safe_load
     SERIALIZERS['yaml'] = yaml
 except ImportError: pass
 
@@ -77,7 +76,10 @@ class Configuration(object):
             if not filetype in SERIALIZERS:
                 sys.stderr.write('Unknown config format %s, parsing as JSON\n' % filetype)
                 filetype = 'json'
-            load = SERIALIZERS[filetype].load
+
+            # Try getting a safe_load function. If absent, use 'load'.
+            load = getattr(SERIALIZERS[filetype], "safe_load",
+                           getattr(SERIALIZERS[filetype], "load"))
 
             config = load(file(filename, 'r'))
             if not config:


### PR DESCRIPTION
Unfortunately replacing `yaml.load` does not work, because it's used in some other places.

Getting the following traceback without the fix:

```
Traceback (most recent call last):
  File "cleopatra/scripts/bootstrap.py", line 9, in <module>
    from clay import config
  File "/Users/ca/.virtualenvs/cleopatra/src/clay-flask/clay/__init__.py", line 2, in <module>
    from clay.server import app
  File "/Users/ca/.virtualenvs/cleopatra/src/clay-flask/clay/server.py", line 8, in <module>
    from clay import config
  File "/Users/ca/.virtualenvs/cleopatra/src/clay-flask/clay/config.py", line 180, in <module>
    CONFIG.load()
  File "/Users/ca/.virtualenvs/cleopatra/src/clay-flask/clay/config.py", line 63, in load
    config = self.load_from_file(path)
  File "/Users/ca/.virtualenvs/cleopatra/src/clay-flask/clay/config.py", line 82, in load_from_file
    config = load(file(filename, 'r'))
  File "/Users/ca/.virtualenvs/cleopatra/lib/python2.7/site-packages/yaml/__init__.py", line 93, in safe_load
    return load(stream, SafeLoader)
TypeError: safe_load() takes exactly 1 argument (2 given)
```
