### PR TITLE
Allow a local env

### DIFF
--- a/clay/config.py
+++ b/clay/config.py
@@ -35,7 +35,7 @@ class Configuration(object):
         '''
         Returns True if this server should use debug configuration and logging
         '''
-        if os.environ.get('CLAY_ENVIRONMENT', None) == 'development':
+        if os.environ.get('CLAY_ENVIRONMENT', None) in ['development', 'local']:
             return True
         else:
             return False


### PR DESCRIPTION
Allow clay to launch in debug mode when the `CLAY_ENVIRONMENT` is `local`.
