### PR TITLE
Only smtp.logic given credentials

### DIFF
--- a/clay/mail.py
+++ b/clay/mail.py
@@ -53,7 +53,8 @@ def sendmail(mailto, subject, message, subtype='html', charset='utf-8', **header
         del msg['BCC']
 
     smtp = smtplib.SMTP(config.get('smtp.host'), config.get('smtp.port'))
-    smtp.login(config.get('smtp.username'), config.get('smtp.password'))
+    if config.get('smtp.username') and config.get('smtp.password'):
+        smtp.login(config.get('smtp.username'), config.get('smtp.password'))
     smtp.sendmail(mailfrom, recipients, msg.as_string())
     smtp.quit()
     log.info('Sent email to %s (Subject: %s)', recipients, subject)


### PR DESCRIPTION
smtp credentials are optional if postfix is properly configured to work without them. In that scenario, smtp.login is no longer needed, and will in fact raise an exception if called. Avoid the invocation when no credentials are supplied on the assumption the email will still be routed properly.
