### PR TITLE
disable clay.stats sending when the host or port is configured as null

### DIFF
--- a/clay/stats.py
+++ b/clay/stats.py
@@ -45,6 +45,9 @@ class StatsConnection(object):
         self.host = config.get('statsd.host', None)
         self.port = config.get('statsd.port', 8125)
 
+        if self.host is None or self.port is None:
+            return None, None
+
         if (self.next_retry is not None) and (self.next_retry > time.time()):
             return
 
@@ -109,7 +112,7 @@ class StatsConnection(object):
         proto, sock = self.get_socket()
         if sock is None:
             return False
-        
+
         if not stat.endswith('\n'):
             stat += '\n'
 


### PR DESCRIPTION
Right now, if you leave it unconfigured in dev, every call to `stats.send` results in the following traceback:

```
  File "/Users/jbrown/uber/mupass/env/lib/python2.7/site-packages/clay/stats.py", line 118, in send
    sock.sendto(stat, 0, (self.host, self.port))
TypeError: coercing to Unicode: need string or buffer, NoneType found
```
