### PR TITLE
Add env variable parsing to yaml config

### DIFF
--- a/clay/config.py
+++ b/clay/config.py
@@ -15,6 +15,17 @@ SERIALIZERS = {'json': json}
 
 try:
     import yaml
+
+    def environment_variable(loader, node):
+        '''
+        Parse "ENV_VAR, default" node values.
+        '''
+
+        env_var, default = loader.construct_scalar(node).split(' or ')
+        return os.environ.get(env_var) or default
+
+    yaml.SafeLoader.add_constructor(u'!env', environment_variable)
+
     SERIALIZERS['yaml'] = yaml
 except ImportError:
     pass


### PR DESCRIPTION
Often we want to specify certain configs using environment variables
(like on a CI server for instance that generates unique ports for
builds). This adds a special yaml constructor that lets you use this
cute syntax:

``` yaml
redis:
  port: !env REDIS_PORT or 4444
```
