### PR TITLE
Add starttls and attachment support to mail.

### DIFF
--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -29,6 +29,8 @@ class TestMail(unittest.TestCase):
         self.assertIn('From: %s' % from_header, args[2])
         self.assertIn('Subject: %s' % subject, args[2])
         self.assertIn('Content-Type: text/html', args[2])
+        self.assertEqual(len(mock_SMTP_instance.elho.call_args_list), 0)
+        self.assertFalse(mock_SMTP_instance.starttls.called)
 
     @mock.patch("smtplib.SMTP")
     def test_sendmail_with_other_smtpconfig(self, mock_SMTP):
@@ -51,3 +53,36 @@ class TestMail(unittest.TestCase):
         self.assertIn('From: %s' % from_header, args[2])
         self.assertIn('Subject: %s' % subject, args[2])
         self.assertIn('Content-Type: text/html', args[2])
+
+    @mock.patch('smtplib.SMTP')
+    def test_sendmail_starttls(self, mock_SMTP):
+        """Test that when use_starttls is true, elho and starttls are called."""
+        mock_SMTP_instance = mock_SMTP.return_value
+
+        mailto = 'otherfake@email.com'
+        subject = 'This is another subject'
+        message = 'This is another message'
+        mail.sendmail(mailto, subject, message, use_starttls=True)
+
+        self.assertEqual(len(mock_SMTP_instance.elho.call_args_list), 2)
+        self.assertTrue(mock_SMTP_instance.starttls.called)
+
+    @mock.patch('smtplib.SMTP')
+    @mock.patch('email.mime.base.MIMEBase.set_payload')
+    def test_sendmail_attachments(self, mock_set_payload, mock_SMTP):
+        """Test that whens sarttls is true, elho and starttls are called."""
+
+        mailto = 'otherfake@email.com'
+        subject = 'This is another subject'
+        message = 'This is another message'
+        file_name = 'my_file_name.txt'
+        file_content = 'this is the content'
+        mail.sendmail(
+            mailto,
+            subject,
+            message,
+            attachments={file_name: file_content}
+        )
+
+        # set_payload should be called on the file content.
+        self.assertIn(file_content, [call[0][0] for call in mock_set_payload.call_args_list])


### PR DESCRIPTION
This PR has 2 purposes:

1) Sending SMTP via gmail (which can be useful when testing before production credentials are ready) requires the  elho -> starttls -> elho calls before authentication.  This PR adds a use_starttls param to the sendmail function.

2) Support for attachments is also added.  This is a port of @mmcclay 's work in chariots.
