### PR TITLE
Public docs are not longer available. Closes #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ Clay is a framework for building RESTful backend services using best practices.
 It's a wrapper around Flask (http://flask.pocoo.org) along with several convenient, standardized, performance enhanced ways of performing common tasks like sending email and connecting to a database.
 
 Clay is available under the MIT License.
-Documentation is available at http://uber.github.com/clay/
 
 Git repository: https://github.com/uber/clay.git
 Install via PyPI: pip install clay-flask


### PR DESCRIPTION
We not longer use the GH version of Clay internally and the previous docs hosted in `uber.github.io` are not available.
